### PR TITLE
Re-add old store format for screens larger than 1600px wide (Desktops)

### DIFF
--- a/assets/screen.css
+++ b/assets/screen.css
@@ -37,7 +37,11 @@ header {
   display: flex;
   justify-content: center;
 }
-
+input[type=submit]{
+  float: right;
+  margin-right: 10%;
+  background-color: #DCDCDC;
+}
 fieldset {
   padding: .5em;
   border: 2px solid #DCDCDC;
@@ -114,7 +118,10 @@ input[type=text], input[type=number], label{
   display: block;
 }
 
-@media screen and (min-width: 480px) {
+@media screen and (min-width: 1000px) {
+  text{
+    font-size: 8em;
+  }
   fieldset {
     padding: .5em;
     border: .125em solid #DCDCDC;
@@ -181,4 +188,31 @@ input[type=text], input[type=number], label{
   input[type=text], input[type=number], label{
     display: block;
   }
+}
+@media screen and (min-width: 1200px) {
+  .product-section{
+    display: inline-block;
+    background-color: white;
+    color: black;
+    width: 15%;
+    margin-top: 1em;
+    position: relative;
+    margin-left: 3.5%;
+    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  }
+  .product-section img{
+    width: 100%;
+    height: 50%;
+  }
+  .product-section button{
+    float: right;
+    margin-right: 2%;
+  }
+  .product-section label, p{
+    margin-left: 3.5%
+  }
+ #store-items-for-sale {
+   display: inline-block;
+   flex-direction: none;
+ }
 }


### PR DESCRIPTION
Also increased the min-width for the tablet screen to kick in; it was displaying on my phone. Firefox Devleoper's simulation of phones was registering the standard iPhone twelve width @ around 680pix